### PR TITLE
feat: Update Claude Code config with envguard hook, statusLine, and effortLevel

### DIFF
--- a/config/claude/CLAUDE.md
+++ b/config/claude/CLAUDE.md
@@ -17,6 +17,8 @@ user impact, business impact, feasibility, and trade-offs for product/business t
 ## Git
 - Use Conventional Commits format (feat:, fix:, docs:, chore:, refactor:, etc.)
 - Write commit messages in English
+- When merging master into a branch, always use `git merge`, never `git rebase`
+- Never create or push git tags without explicit confirmation from the user
 
 ## Working Style
 - Plan before acting. Outline the approach and confirm before starting implementation

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -3,10 +3,10 @@
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
-  "language": "japanese",
-  "alwaysThinkingEnabled": true,
-  "teammateMode": "tmux",
-  "model": "sonnet",
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "permissions": {
     "deny": [
       "Read(**/.env)",
@@ -35,11 +35,18 @@
       "Write(**/*_ed25519)"
     ]
   },
-  "attribution": {
-    "commit": "",
-    "pr": ""
-  },
+  "model": "sonnet",
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/opt/homebrew/bin/envguard --hook"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [
@@ -93,5 +100,13 @@
         ]
       }
     ]
-  }
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "bash /Users/winky/.claude/statusline-command.sh"
+  },
+  "language": "japanese",
+  "alwaysThinkingEnabled": true,
+  "teammateMode": "tmux",
+  "effortLevel": "high"
 }


### PR DESCRIPTION
## Summary

- Add `SessionStart` hook to run `envguard --hook` at session start
- Add `statusLine` command configuration using `statusline-command.sh`
- Add `effortLevel: high` setting
- Add git merge/tag rules to `CLAUDE.md`

## Changes

- `config/claude/CLAUDE.md`: Added rules for using `git merge` (not rebase) and requiring confirmation before creating/pushing tags
- `config/claude/settings.json`: Added `SessionStart` hook, `statusLine`, and `effortLevel` settings